### PR TITLE
Usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,35 @@ llvm-general-quote
 `llvm-general-quote` is a quasiquoting-library for llvm-general.
 It aims to support all language constructs of llvm.
 
+`llvm-general-quote` provides both quasiquotes and antiquotes. The following trivial example uses both a quasiquote and an antiquote.
+
+```
+alloc :: Type -> Instruction
+alloc t = [lli|alloc $type:t|]
+```
+
+`LLVM.General.Quote.LLVM` provides quasiquoters or antiquoters for the following types. For each type `a`, there's also a corresponding quasiquoter or antiquoter for `CodeGen a` with an `M` added to the end of the name. For example, `Definition`'s quasiquoter is `lldef`; the corresponding quasiquoter for `CodeGen Definition` is `lldefM`. Its antiquoter is `$def:`; the corresponding antiquoter for `CodeGen Definition` is `$defM:`.
+
+AST Type                                     | Quasiquoter | Antiquoter
+-------------------------------------------- | ----------- | ----------
+`LLVM.General.AST.Module`                    | `llmod`     |
+`LLVM.General.AST.Definition`                | `lldef`     | `$def:`
+`[LLVM.General.AST.Definition]`              |             | `$defs:`
+`LLVM.General.AST.Global`                    | `llg`       |
+`LLVM.General.AST.Instruction.Instruction`   | `lli`       | `$instr:`
+`[LLVM.General.AST.Instruction.Instruction]` |             | `$instrs:`
+`LLVM.General.AST.DataLayout.DataLayout`     |             | `$dl:`
+`LLVM.General.Quote.AST.TargetTriple`        |             | `$tt:`
+`LLVM.General.AST.BasicBlock`                |             | `$bb:`
+`[LLVM.General.AST.BasicBlock]`              |             | `$bbs:`
+`LLVM.General.AST.Type.Type`                 |             | `$type:`
+`LLVM.General.AST.Operand.Operand`           |             | `$opr:`
+`LLVM.General.AST.Constant.Constant`         |             | `$const:`
+`LLVM.General.AST.Name.Name` (local)         |             | `$id:`
+`LLVM.General.AST.Name.Name` (global)        |             | `$gid:`
+`LLVM.General.AST.Parameter`                 |             | `$param:`
+`[LLVM.General.AST.Parameter]`               |             | `$params:`
+
 In addtion to this, it supports using mutable variables and control structures instead of pure SSA form.
 This is translated automatically into SSA through appropriate renaming.
 

--- a/src/LLVM/General/Quote/Base.hs
+++ b/src/LLVM/General/Quote/Base.hs
@@ -81,6 +81,8 @@ instance ToDefintion a => ToDefintions [a] where
 
 class ToConstant a where
   toConstant :: a -> L.Constant
+instance ToConstant L.Constant where
+  toConstant = id
 instance ToConstant Word8 where
   toConstant n = L.Int 8 (toInteger n)
 instance ToConstant Word16 where

--- a/src/LLVM/General/Quote/Parser/Parser.y
+++ b/src/LLVM/General/Quote/Parser/Parser.y
@@ -285,7 +285,7 @@ import qualified LLVM.General.AST.DataLayout as A
  - Constants
  -
  -----------------------------------------------------------------------------}
-
+    
 constant :: { A.Type -> A.Constant }
 constant :
     INT                   { intConstant $1 }
@@ -303,22 +303,28 @@ constant :
                           { \_ -> A.BlockAddress $3 $5 }
   | 'undef'               { A.Undef }
   | globalName            { \t -> A.GlobalReference t $1 }
-  | ANTI_CONST            { \_ -> A.AntiConstant $1 }
+  | cConstant             { \_ -> $1 }
 
 tConstant :: { A.Constant }
 tConstant :
     type constant         { $2 $1 }
+  | cConstant             { $1 }
 
 mConstant :: { A.Type -> Maybe A.Constant }
 mConstant :
     {- empty -}            { \_ -> Nothing }
   | constant               { Just . $1 }
-
+  
 constantList :: { RevList A.Constant }
 constantList :
     tConstant                    { RCons $1 RNil }
   | constantList ',' tConstant   { RCons $3 $1 }
 
+{- Constants that don't require a type -}
+cConstant :: { A.Constant }
+cConstant :
+    ANTI_CONST            { A.AntiConstant $1 }
+    
 {------------------------------------------------------------------------------
  -
  - Operands
@@ -331,7 +337,7 @@ operand :
   | name                { \t -> A.LocalReference t $1 }
   | '!' STRING          { \A.MetadataType -> A.MetadataStringOperand $2 }
   | metadataNode        { \A.MetadataType -> A.MetadataNodeOperand $1 }
-  | ANTI_OPR            { \_ -> A.AntiOperand $1 }
+  | cOperand            { \_ -> $1 }
 
 mOperand :: { Maybe A.Operand }
 mOperand :
@@ -341,6 +347,18 @@ mOperand :
 tOperand :: { A.Operand }
 tOperand :
     type operand        { $2 $1 }
+  | cOperand            { $1 }
+    
+{- Operands that don't require a type -}
+cOperand :: { A.Operand }
+cOperand :
+   ANTI_OPR            { A.AntiOperand $1 }
+
+{- Binary operator operands -}
+binOperands :: { (A.Operand, A.Operand) }
+binOperands :
+    type operand ',' operand    { ($2 $1, $4 $1) }
+  | cOperand ',' cOperand       { ($1, $3) }
 
 {------------------------------------------------------------------------------
  -
@@ -603,24 +621,24 @@ instructionMetadata :
 
 instruction_ :: { A.InstructionMetadata -> A.Instruction }
 instruction_ :
-    'add' nuw nsw type operand ',' operand  { A.Add $3 $2 ($5 $4) ($7 $4) }
-  | 'fadd' fmflags type operand ',' operand { A.FAdd $2 ($4 $3) ($6 $3) }
-  | 'sub' nuw nsw type operand ',' operand  { A.Sub $3 $2 ($5 $4) ($7 $4) }
-  | 'fsub' fmflags type operand ',' operand { A.FSub $2 ($4 $3) ($6 $3) }
-  | 'mul' nuw nsw type operand ',' operand  { A.Mul $3 $2 ($5 $4) ($7 $4) }
-  | 'fmul' fmflags type operand ',' operand { A.FMul $2 ($4 $3) ($6 $3) }
-  | 'udiv' exact type operand ',' operand   { A.UDiv $2 ($4 $3) ($6 $3) }
-  | 'sdiv' exact type operand ',' operand   { A.SDiv $2 ($4 $3) ($6 $3) }
-  | 'fdiv' fmflags type operand ',' operand { A.FDiv $2 ($4 $3) ($6 $3) }
-  | 'urem' type operand ',' operand         { A.URem ($3 $2) ($5 $2) }
-  | 'srem' type operand ',' operand         { A.SRem ($3 $2) ($5 $2) }
-  | 'frem' fmflags type operand ',' operand { A.FRem $2 ($4 $3) ($6 $3) }
-  | 'shl' nuw nsw type operand ',' operand  { A.Shl $3 $2 ($5 $4) ($7 $4) }
-  | 'lshr' exact type operand ',' operand   { A.LShr $2 ($4 $3) ($6 $3) }
-  | 'ashr' exact type operand ',' operand   { A.AShr $2 ($4 $3) ($6 $3) }
-  | 'and' type operand ',' operand          { A.And ($3 $2) ($5 $2) }
-  | 'or' type operand ',' operand           { A.Or ($3 $2) ($5 $2) }
-  | 'xor' type operand ',' operand          { A.Xor ($3 $2) ($5 $2) }
+    'add' nuw nsw binOperands   { A.Add $3 $2 (fst $4) (snd $4) }
+  | 'fadd' fmflags binOperands  { A.FAdd $2 (fst $3) (snd $3) }
+  | 'sub' nuw nsw binOperands   { A.Sub $3 $2 (fst $4) (snd $4) }
+  | 'fsub' fmflags binOperands  { A.FSub $2 (fst $3) (snd $3) }
+  | 'mul' nuw nsw binOperands   { A.Mul $3 $2 (fst $4) (snd $4) }
+  | 'fmul' fmflags binOperands  { A.FMul $2 (fst $3) (snd $3) }
+  | 'udiv' exact binOperands    { A.UDiv $2 (fst $3) (snd $3) }
+  | 'sdiv' exact binOperands    { A.SDiv $2 (fst $3) (snd $3) }
+  | 'fdiv' fmflags binOperands  { A.FDiv $2 (fst $3) (snd $3) }
+  | 'urem' binOperands          { A.URem (fst $2) (snd $2) }
+  | 'srem' binOperands          { A.SRem (fst $2) (snd $2) }
+  | 'frem' fmflags binOperands  { A.FRem $2 (fst $3) (snd $3) }
+  | 'shl' nuw nsw binOperands   { A.Shl $3 $2 (fst $4) (snd $4) }
+  | 'lshr' exact binOperands    { A.LShr $2 (fst $3) (snd $3) }
+  | 'ashr' exact binOperands    { A.AShr $2 (fst $3) (snd $3) }
+  | 'and' binOperands           { A.And (fst $2) (snd $2) }
+  | 'or' binOperands            { A.Or (fst $2) (snd $2) }
+  | 'xor' binOperands           { A.Xor (fst $2) (snd $2) }
   | 'alloca' type mOperand alignment        { A.Alloca $2 $3 $4 }
   | 'load' volatile tOperand alignment      { A.Load $2 $3 Nothing $4 }
   | 'load' 'atomic' volatile tOperand atomicity alignment      { A.Load $3 $4 (Just $5) $6 }
@@ -652,8 +670,8 @@ instruction_ :
   | 'inttoptr' tOperand 'to' type           { A.IntToPtr $2 $4 }
   | 'bitcast' tOperand 'to' type            { A.BitCast $2 $4 }
   | 'addrspacecast' tOperand 'to' type      { A.AddrSpaceCast $2 $4 }
-  | 'icmp' intP type operand ',' operand    { A.ICmp $2 ($4 $3) ($6 $3) }
-  | 'fcmp' fpP type operand ',' operand     { A.FCmp $2 ($4 $3) ($6 $3) }
+  | 'icmp' intP binOperands                 { A.ICmp $2 (fst $3) (snd $3) }
+  | 'fcmp' fpP binOperands                  { A.FCmp $2 (fst $3) (snd $3) }
   | 'phi' type phiList                      { A.Phi $2 (rev ($3 $2)) }
   | tail 'call' cconv parameterAttributes callableOperand '(' argumentList ')' fAttributes
                                             { A.Call $1 $3 (rev $4) ($5 (map fst (rev $7))) (map snd (rev $7)) (rev $9) }
@@ -663,8 +681,8 @@ instruction_ :
   | 'extractelement' tOperand ',' tOperand  { A.ExtractElement $2 $4 }
   | 'insertelement' tOperand ',' tOperand ',' tOperand
                                             { A.InsertElement $2 $4 $6 }
-  | 'shufflevector' tOperand ',' tOperand ',' type constant
-                                            { A.ShuffleVector $2 $4 ($7 $6) }
+  | 'shufflevector' tOperand ',' tOperand ',' tConstant
+                                            { A.ShuffleVector $2 $4 $6 }
   | 'extractvalue' tOperand ',' idxs        { A.ExtractValue $2 (rev $4) }
   | 'insertvalue' tOperand ',' tOperand ',' idxs
                                             { A.InsertValue $2 $4 (rev $6) }

--- a/src/LLVM/General/Quote/Parser/Parser.y
+++ b/src/LLVM/General/Quote/Parser/Parser.y
@@ -13,6 +13,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Maybe (fromMaybe, catMaybes, listToMaybe)
 import Data.Word
+import Data.Char (ord)
 import Text.PrettyPrint.Mainland
 
 import LLVM.General.Quote.Parser.Lexer
@@ -39,6 +40,7 @@ import qualified LLVM.General.AST.DataLayout as A
  INT                 { L _ (T.TintConst $$) }
  FLOAT               { L _ (T.TfloatConst $$) }
  STRING              { L _ (T.TstringConst $$) }
+ CSTRING             { L _ (T.TcstringConst $$) }
  NAMED_GLOBAL        { L _ (T.Tnamed T.Global $$) }
  NAMED_LOCAL         { L _ (T.Tnamed T.Local $$) }
  NAMED_META          { L _ (T.Tnamed T.Meta $$) }
@@ -309,6 +311,7 @@ fConstant :
 cConstant :: { A.Constant }
 cConstant :
     ANTI_CONST            { A.AntiConstant $1 }
+  | CSTRING               { A.Array (A.IntegerType 8) (map (A.Int 8 . fromIntegral . ord) $1) }
     
 constant :: { A.Type -> A.Constant }
 constant :

--- a/src/LLVM/General/Quote/Parser/Tokens.hs
+++ b/src/LLVM/General/Quote/Parser/Tokens.hs
@@ -25,6 +25,7 @@ data Token
   | TintConst Integer
   | TfloatConst Rational
   | TstringConst String
+  | TcstringConst String
   | Tnamed Visibility String
   | Tunnamed Visibility Word
   | TjumpLabel String
@@ -262,6 +263,7 @@ instance Show Token where
   show (TintConst _) = "INT"
   show (TfloatConst _) = "FLOAT"
   show (TstringConst _) = "STRING"
+  show (TcstringConst _) = "CSTRING"
   show (Tnamed Global _) = "NAMED_GLOBAL"
   show (Tnamed Local _) = "NAMED_LOCAL"
   show (Tnamed Meta _) = "NAMED_META"


### PR DESCRIPTION
Thanks for writing such an excellent library. It's obvious that a lot of effort has gone into the parser, which I am grateful for.

These changes improve the usability of llvm-general-quote. The first change allows using an antiquoted `Operand` anywhere an operand is needed. It's now possible to write, for example:

```
add' :: Operand -> Operand -> Instruction
add' a b = [lli|add $opr:a $opr:b|]
```

It includes a parallel change to `Constant`.

The second change improves the readme.md documentation by providing basic examples of use and listing the provided quoters and antiquoters.

The third change allows `Constant`s to be used where `Operand`s are needed. It allows writing code like

```
addc :: Constant -> Operand -> Instruction
addc a b = [lli|add $const:a $opr:b]
```

It requires a bit more explanation. It is accomplished by partitioning the constants between those that do require a type (`fConstant`) and those that do not (`cConstant`). The partitioning allows the ones that are not a function of a type to be treated as operands that do not require a function (`cOperand`) without appearing twice in the definition of operands that are functions of a type (`operand`).